### PR TITLE
Directly call mongo client close instead of disconnect

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -115,7 +115,7 @@ class MongoDB(object):
             self.submit('file_size', 'index', db_stats['indexSize'], mongo_db)
             self.submit('file_size', 'data', db_stats['dataSize'], mongo_db)
 
-        con.disconnect()
+        con.close()
 
     def config(self, obj):
         for node in obj.children:


### PR DESCRIPTION
Non fatal error but clogging the logs since disconnect was removed from pymongo in https://github.com/mongodb/mongo-python-driver/commit/7f42430978310e8bd9c4ed2995abd7da24c0f52f