### PR TITLE
Use LooseVersion for versions like 3.2.9-rc0

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -5,7 +5,7 @@
 import collectd
 from pymongo import MongoClient
 from pymongo.read_preferences import ReadPreference
-from distutils.version import StrictVersion as V
+from distutils.version import LooseVersion as V
 
 
 class MongoDB(object):


### PR DESCRIPTION
Fixes errors like

```
Unhandled python exception in read callback: ValueError: invalid version number '3.2.9-rc0'
read-function of plugin `python.mongodb' failed. Will suspend it for 120.000 seconds.
```